### PR TITLE
Fix transparency handling in thumbnail generator

### DIFF
--- a/backend/thumbnail.py
+++ b/backend/thumbnail.py
@@ -102,7 +102,10 @@ class ThumbnailGenerator:
     def generate_thumbnail_template(self, image_url: str, metadata: dict) -> str:
         image = self.download_image(image_url).resize((1280, 720), Image.Resampling.LANCZOS)
         overlay = Image.new('RGBA', image.size, (0, 0, 0, int(255 * self.overlay_opacity)))
-        image = Image.alpha_composite(image.convert('RGBA'), overlay).convert('RGB')
+        # Keep image in RGBA mode so elements with transparency (e.g. date
+        # background) render correctly. Converting to RGB here would drop the
+        # alpha channel and make semi-transparent overlays fully opaque.
+        image = Image.alpha_composite(image.convert('RGBA'), overlay)
         draw = ImageDraw.Draw(image)
 
         heading = metadata.get("heading", "").upper()


### PR DESCRIPTION
## Summary
- preserve RGBA channel in generated thumbnails so semi-transparent elements render

## Testing
- `python -m py_compile backend/thumbnail.py backend/main.py backend/groq.py backend/unsplash.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68700fa0940c832a9548d998e8ee9d73